### PR TITLE
o-mr1 patches

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -65,6 +65,7 @@ popd
 pushd $ANDROOT/system/core
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/system/core"
 git fetch $LINK refs/changes/21/553221/1 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/41/501741/2 && git cherry-pick FETCH_HEAD
 popd
 
 pushd $ANDROOT/frameworks/av

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -44,6 +44,7 @@ LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/audio"
 git fetch $LINK refs/changes/91/294291/1 && git cherry-pick FETCH_HEAD
 git fetch $LINK refs/changes/63/573163/1 && git cherry-pick FETCH_HEAD
 git fetch $LINK refs/changes/56/535256/1 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/43/576643/1 && git cherry-pick FETCH_HEAD
 popd
 
 pushd $ANDROOT/hardware/qcom/media

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -55,6 +55,7 @@ pushd $ANDROOT/hardware/qcom/display
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/display"
 git fetch $LINK refs/changes/35/437235/1 && git cherry-pick FETCH_HEAD
 git fetch $LINK refs/changes/83/573183/1 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/42/576642/1 && git cherry-pick FETCH_HEAD
 popd
 
 pushd $ANDROOT/hardware/qcom/bt


### PR DESCRIPTION
These patches do the following:
1. allow loire devices to load audio xmls from /vendor
2. avoid a crash in hwc2 due to failure to init color mode
3. allow loading of firmware files from /odm