### PR TITLE
[android-8.1.0_r3.] system: core: Bring back board overrides in mode_charger

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -67,6 +67,8 @@ pushd $ANDROOT/system/core
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/system/core"
 git fetch $LINK refs/changes/21/553221/1 && git cherry-pick FETCH_HEAD
 git fetch $LINK refs/changes/41/501741/2 && git cherry-pick FETCH_HEAD
+git revert --no-edit 1d540dd0f44c1c7d40878f6a7bb447e85e6207ad
+git fetch $LINK refs/changes/37/469437/1 && git cherry-pick FETCH_HEAD
 popd
 
 pushd $ANDROOT/frameworks/av


### PR DESCRIPTION
This patch reverts
https://android.googlesource.com/platform/system/core/+/1d540dd0f44c1c7d40878f6a7bb447e85e6207ad
which is splitting battery draw

and bring back
https://android-review.googlesource.com/c/platform/system/core/+/469437
which allow current sources to be used as an override.

Although charger is still broken due to init.rc rework but it is necessary
to load sony healthd sources properly.

Signed-off-by: Humberto Borba <humberos@gmail.com>