### PR TITLE
[android-8.1.0_r3] frameworks: native: Graphics: Avoid vulkan libs access if vulkan is d…

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -76,6 +76,11 @@ LINK=$HTTP && LINK+="://android.googlesource.com/platform/frameworks/av"
 git fetch $LINK refs/changes/92/384692/2 && git cherry-pick FETCH_HEAD
 popd
 
+pushd $ANDROOT/frameworks/native
+LINK=$HTTP && LINK+="://android.googlesource.com/platform/frameworks/native"
+git fetch $LINK refs/changes/54/603554/1 && git cherry-pick FETCH_HEAD
+popd
+
 pushd $ANDROOT/packages/inputmethods/LatinIME
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/packages/inputmethods/LatinIME"
 git fetch $LINK refs/changes/78/469478/1 && git cherry-pick FETCH_HEAD


### PR DESCRIPTION
Graphics: Avoid vulkan libs access if vulkan is disabled

Some CTS tests open vulkan libs without checking permission
files. Avoid loading of vulkan libs if vulkan is disabled.

Signed-off-by: Humberto Borba <humberos@omnirom.org>