### PR TITLE
Revert "frameworks: native: Graphics: Avoid vulkan libs access if vul…

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -79,11 +79,6 @@ LINK=$HTTP && LINK+="://android.googlesource.com/platform/frameworks/av"
 git fetch $LINK refs/changes/92/384692/2 && git cherry-pick FETCH_HEAD
 popd
 
-pushd $ANDROOT/frameworks/native
-LINK=$HTTP && LINK+="://android.googlesource.com/platform/frameworks/native"
-git fetch $LINK refs/changes/54/603554/1 && git cherry-pick FETCH_HEAD
-popd
-
 pushd $ANDROOT/packages/inputmethods/LatinIME
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/packages/inputmethods/LatinIME"
 git fetch $LINK refs/changes/78/469478/1 && git cherry-pick FETCH_HEAD


### PR DESCRIPTION
…kan is disabled"

We do not have MSM8952 so this patch is not necessary.

This reverts commit 9307b1e3257ae2cc909c466533c37f37d1c910d5.