### PR TITLE
Add display HAL patch that lets us load proper HWCColorManager lib

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -62,6 +62,7 @@ LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/display"
 git fetch $LINK refs/changes/35/437235/1 && git cherry-pick FETCH_HEAD
 git fetch $LINK refs/changes/42/576642/1 && git cherry-pick FETCH_HEAD
 git fetch $LINK refs/changes/38/602838/1 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/79/645379/1 && git cherry-pick FETCH_HEAD
 popd
 
 pushd $ANDROOT/hardware/qcom/bt


### PR DESCRIPTION
* Before:
  HWCColorManager::CreateColorManager: Unable to load = libsdm-disp-apis.so
* After:
  HWCColorManager::CreateColorManager: Successfully loaded libsdm-disp-vndapis.so
* Gerrit change: https://android-review.googlesource.com/#/c/platform/hardware/qcom/display/+/645379/