### PR TITLE
Make local_manifests sync skippable too

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -16,11 +16,11 @@ popd () {
     command popd "$@" > /dev/null
 }
 
-pushd $ANDROOT/.repo/local_manifests
-git pull
-popd
-
 if [ "$SKIP_SYNC" != "TRUE" ]; then
+    pushd $ANDROOT/.repo/local_manifests
+    git pull
+    popd
+
     repo sync -j8 --current-branch --no-tags
 fi
 


### PR DESCRIPTION
Based on @jamuir's idea: https://github.com/sonyxperiadev/repo_update/commit/6c6a0e3c35ceceaed597260f7f825e2733149b1e#comments.

If one uses custom repo sync parametes, he'll surely sync local_manifests manually as well, otherwise he may be missing some repositories.