### PR TITLE
Add patch for two-step OTAs.

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -37,6 +37,11 @@ git cherry-pick d00f5eb63a8e4690f9bef1e943d539d052444d9b
 git fetch $LINK refs/changes/15/538015/2 && git cherry-pick FETCH_HEAD
 popd
 
+pushd $ANDROOT/build
+LINK=$HTTP && LINK+="://android.googlesource.com/platform/build"
+git cherry-pick 47ec5ab561bd979560bde402201268486ce9cc34
+popd
+
 pushd $ANDROOT/external/toybox
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/external/toybox"
 git fetch $LINK refs/changes/74/265074/1 && git cherry-pick FETCH_HEAD


### PR DESCRIPTION
https://android.googlesource.com/platform/build/+/47ec5ab561bd979560bde402201268486ce9cc34

Build recovery-two-step.img for two-step OTAs.

In two-step OTAs, we write recovery image to /boot as the first step so
that we can reboot from there and install a new recovery image to
/recovery. However, bootloader will show "Your device is corrupt"
message when booting /boot with the recovery image. Because the recovery
image encodes the path of "/recovery" as part of the signature metadata,
which fails the verified boot.

This CL generates a special "recovery-two-step.img" in addition to the
regular recovery.img. This image encodes "/boot" when being signed,
which will be flashed to /boot at stage 1/3 in a two-step OTA.