### PR TITLE
Add patches required to build using sdm845 hals and 4.9 kernel headers

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -48,17 +48,21 @@ popd
 
 pushd $ANDROOT/hardware/qcom/audio
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/audio"
-git fetch $LINK refs/changes/91/294291/1 && git cherry-pick FETCH_HEAD
-git fetch $LINK refs/changes/63/573163/1 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/08/708808/1 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/09/708809/1 && git cherry-pick FETCH_HEAD
 git fetch $LINK refs/changes/56/535256/1 && git cherry-pick FETCH_HEAD
 git fetch $LINK refs/changes/43/576643/1 && git cherry-pick FETCH_HEAD
-git fetch $LINK refs/changes/41/602841/3 && git cherry-pick FETCH_HEAD
-git fetch $LINK refs/changes/42/602842/1 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/41/602841/4 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/42/602842/2 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/10/708810/1 && git cherry-pick FETCH_HEAD
 popd
 
 pushd $ANDROOT/hardware/qcom/media
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/media"
 git fetch $LINK refs/changes/55/522855/1 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/15/708815/1 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/16/708816/1 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/17/708817/1 && git cherry-pick FETCH_HEAD
 popd
 
 pushd $ANDROOT/hardware/qcom/display
@@ -67,11 +71,19 @@ git fetch $LINK refs/changes/35/437235/1 && git cherry-pick FETCH_HEAD
 git fetch $LINK refs/changes/42/576642/1 && git cherry-pick FETCH_HEAD
 git fetch $LINK refs/changes/38/602838/1 && git cherry-pick FETCH_HEAD
 git fetch $LINK refs/changes/79/645379/1 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/12/708812/1 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/13/708813/1 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/14/708814/1 && git cherry-pick FETCH_HEAD
 popd
 
 pushd $ANDROOT/hardware/qcom/bt
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/bt"
 git fetch $LINK refs/changes/84/573184/1 && git cherry-pick FETCH_HEAD
+popd
+
+pushd $ANDROOT/hardware/qcom/bootctrl
+LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/bootctrl"
+git fetch $LINK refs/changes/11/708811/1 && git cherry-pick FETCH_HEAD
 popd
 
 pushd $ANDROOT/system/core


### PR DESCRIPTION
Added patches:
https://android-review.googlesource.com/c/platform/hardware/qcom/audio/+/708808 Add msm8976 tasha sound card detection to msm8916 HAL
https://android-review.googlesource.com/c/platform/hardware/qcom/audio/+/708809 post_proc: Enable post processing for msm8952
https://android-review.googlesource.com/c/platform/hardware/qcom/audio/+/708810 audio: add support for sdm845 platform
https://android-review.googlesource.com/c/platform/hardware/qcom/bootctrl/+/708811 Replace hardcoded build barier with a generic one
https://android-review.googlesource.com/c/platform/hardware/qcom/display/+/708812 display: add barier for kernel headers
https://android-review.googlesource.com/c/platform/hardware/qcom/display/+/708813 display: remove blob dependency
https://android-review.googlesource.com/c/platform/hardware/qcom/display/+/708814 display: fix undeclared variable
https://android-review.googlesource.com/c/platform/hardware/qcom/media/+/708815 media: add barier for kernel headers
https://android-review.googlesource.com/c/platform/hardware/qcom/media/+/708816 media: disabled functions that need blobs
https://android-review.googlesource.com/c/platform/hardware/qcom/media/+/708817 msm8952: fix registry_table name

Updated patches:
https://android-review.googlesource.com/c/platform/hardware/qcom/audio/+/602841 hal: enable audio hal on sdm660
https://android-review.googlesource.com/c/platform/hardware/qcom/audio/+/602842 post_proc: Enable post processing for sdm660

Removed patches:
https://android-review.googlesource.com/c/platform/hardware/qcom/audio/+/294291
https://android-review.googlesource.com/c/platform/hardware/qcom/audio/+/573163