### PR TITLE
[7.1.1_r55] Add patch to use zip64 for signing TF.zip

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -40,6 +40,7 @@ popd
 pushd $ANDROOT/build
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/build"
 git cherry-pick 47ec5ab561bd979560bde402201268486ce9cc34
+git cherry-pick 2b8f489e304e1afd7ae607000d5e7022328293db
 popd
 
 pushd $ANDROOT/external/toybox


### PR DESCRIPTION
Allow sign_target_files_apks.py to create zip64 signed TF.zip.
- https://android.googlesource.com/platform/build/+/2b8f489e304e1afd7ae607000d5e7022328293db