### PR TITLE
[8.0.0_r33]  Add patch to use zip64 for signing TF.zip

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -34,6 +34,11 @@ git cherry-pick 846012fc444e6076dabf874ed8cbdab358c2e0fb
 git fetch $LINK refs/changes/35/517735/2 && git cherry-pick FETCH_HEAD
 popd
 
+pushd $ANDROOT/build/make
+LINK=$HTTP && LINK+="://android.googlesource.com/platform/build"
+git cherry-pick 2b8f489e304e1afd7ae607000d5e7022328293db
+popd
+
 pushd $ANDROOT/external/wpa_supplicant_8
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/external/wpa_supplicant_8"
 git fetch $LINK refs/changes/00/512300/1 && git cherry-pick FETCH_HEAD

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -34,11 +34,6 @@ git cherry-pick 846012fc444e6076dabf874ed8cbdab358c2e0fb
 git fetch $LINK refs/changes/35/517735/2 && git cherry-pick FETCH_HEAD
 popd
 
-pushd $ANDROOT/build
-LINK=$HTTP && LINK+="://android.googlesource.com/platform/build"
-git cherry-pick 2b8f489e304e1afd7ae607000d5e7022328293db
-popd
-
 pushd $ANDROOT/external/wpa_supplicant_8
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/external/wpa_supplicant_8"
 git fetch $LINK refs/changes/00/512300/1 && git cherry-pick FETCH_HEAD


### PR DESCRIPTION
Fix path of previous commit. Since Android 8.0, platform/build repository has been moved to build/make so patch has to be applied on it.