### PR TITLE
Add: hardware/qcom/media patches for compatibility with 4.9 kernel

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -53,6 +53,8 @@ popd
 pushd $ANDROOT/hardware/qcom/media
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/media"
 git fetch $LINK refs/changes/39/728339/1 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/55/813054/1 && git cherry-pick FETCH_HEAD
+git fetch $LINK refs/changes/55/813055/1 && git cherry-pick FETCH_HEAD
 popd
 
 pushd $ANDROOT/hardware/qcom/display


### PR DESCRIPTION
4.9 kernel introduces a new vidc driver, while keeping the legacy driver.
Unfortunately, the sdm845 media hal only works with the new driver, so old devices need to use the msm8998 media hal.
The msm8998 hal is expecting 4.4 kernel headers though, so it fails compilation on 4.9.
These patches make the hal build with 4.9 kernel headers, allowing legacy devices to have functional vidc.