### PR TITLE
Add: hardware/qcom/media patches for compatibility with 4.9 kernel

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -89,6 +89,12 @@ git fetch $LINK refs/changes/42/713242/2 && git cherry-pick FETCH_HEAD
 # msm8996: fix build when prop blobs are not prezent
 # Change-Id: I86baddb52292e65ee4a5d8dae6253920b9c0629b
 git fetch $LINK refs/changes/43/713243/2 && git cherry-pick FETCH_HEAD
+# msm8998: mm-video-v4l2: enable compilation for both 3.18 kernel and 4.9 kernel
+# Change-Id: If1eb2575dd80a1e6684c84e573baf78ae698bb20
+git fetch $LINK refs/changes/55/813054/1 && git cherry-pick FETCH_HEAD
+# msm8998: mm-video-v4l2: Renaming the AU-Delimiter params/extens
+# Change-Id: I3feccfbb06e4e237a601a355ab2f2573a165ed3b
+git fetch $LINK refs/changes/55/813055/1 && git cherry-pick FETCH_HEAD
 popd
 
 pushd $ANDROOT/hardware/qcom/display


### PR DESCRIPTION
4.9 kernel introduces a new vidc driver, while keeping the legacy driver.
Unfortunately, the sdm845 media hal only works with the new driver, so old devices need to use the msm8998 media hal.
The msm8998 hal is expecting 4.4 kernel headers though, so it fails compilation on 4.9.
These patches make the hal build with 4.9 kernel headers, allowing legacy devices to have functional vidc.