### PR TITLE
[DONOTMERGE] Remove bootctrl patches in favor of TARGET_USES_HARDWARE_QCOM_BOOTCTRL.

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -137,19 +137,6 @@ LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/bt"
 git fetch $LINK refs/changes/69/728569/1 && git cherry-pick FETCH_HEAD
 popd
 
-pushd $ANDROOT/hardware/qcom/bootctrl
-LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/bootctrl"
-# bootcontrol: Add TARGET_USES_HARDWARE_QCOM_BOOTCTRL
-# Change-Id: I958bcf29da2ea5914ac503e9d209c75ce44f1e51
-git revert --no-edit f5db01c3b14d720f3d603cfb3b887d89c2b11b28
-# Android.mk: add sdm710
-# Change-Id: I82f2321d580cb2fdb15d2343e39abed5ccda50b1
-git revert --no-edit a8e07aecb24898d7d2b49cb785b0c193a4b134b4
-# Replace hardcoded build barrier with a generic one
-# Change-Id: I34ee90a2818ad23cc6b9233bdde126a0965fae0d
-git fetch $LINK refs/changes/70/728570/2 && git cherry-pick FETCH_HEAD
-popd
-
 pushd $ANDROOT/hardware/nxp/nfc
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/nxp/nfc"
 # hardware: nxp: Restore pn548 support


### PR DESCRIPTION
Platforms that need bootctrl already set `TARGET_USES_HARDWARE_QCOM_BOOTCTRL`, which is necessary to build the HAL for devices not listed in the hardcoded platform list. It is not necessary to revert and apply patches that respond to `AB_OTA_UPDATER` instead.

DONOTMERGE:
There are some changes going on in android-q/master that alter the behavior of compiling this module. Most notably the switch to .bp and removing the `TARGET_USES_HARDWARE_QCOM_BOOTCTRL := true` overide for select platforms (that we _do not want_ for certain platforms). Let's wait out and see which of those two changes make it to Q before progressing with this PR.
https://android.googlesource.com/platform/build/+/master/Changes.md#PRODUCT_STATIC_BOOT_CONTROL_HAL Given that this documentation exists, it might be safe to say this change is ready and going to come through in Q - I'll submit the right patches whenever that happens.