### PR TITLE
Remove system/core bootanimation patch

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -176,13 +176,6 @@ git fetch $LINK refs/changes/05/728605/1 && git cherry-pick FETCH_HEAD
 git fetch $LINK refs/changes/40/824340/1 && git cherry-pick FETCH_HEAD
 popd
 
-pushd $ANDROOT/system/core
-LINK=$HTTP && LINK+="://android.googlesource.com/platform/system/core"
-# Show bootanimation after decrypt
-# Change-Id: I355ccdbb2e2f27d897e2e0ee00f9300ef38ede03
-git fetch $LINK refs/changes/01/741001/2 && git cherry-pick FETCH_HEAD
-popd
-
 # because "set -e" is used above, when we get to this point, we know
 # all patches were applied successfully.
 echo "+++ all patches applied successfully! +++"


### PR DESCRIPTION
We used to patch this via https://r.android.com/741001
```
 on property:vold.decrypt=trigger_restart_framework
-    stop surfaceflinger
-    start surfaceflinger
     # A/B update verifier that marks a successful boot.
     exec_start update_verifier
     class_start main
     class_start late_start
+    setprop service.bootanim.exit 0
+    start bootanim
```
The patch no longer applies since the following patch to system/core was merged into the 2019-07 security patch branches:
@c61ef4: Start update_verifier early in late-fs
https://android.googlesource.com/platform/system/core/+/c61ef4
```
 on property:vold.decrypt=trigger_restart_framework
     stop surfaceflinger
     start surfaceflinger
-    # A/B update verifier that marks a successful boot.
-    exec_start update_verifier
     class_start main
     class_start late_start
```
Besides, the patch was only ever cosmetic.