### PR TITLE
[Android 10] Remove backports; fix upstream bugs; local patchfiles.

### DIFF
--- a/frameworks/base/0001-Add-camera-key-long-press-handling.patch
+++ b/frameworks/base/0001-Add-camera-key-long-press-handling.patch
@@ -1,0 +1,166 @@
+From 951408a780991c35545a19bdeb8699920de4d0da Mon Sep 17 00:00:00 2001
+From: Pablo Mendez Hernandez <pablomh@gmail.com>
+Date: Wed, 8 Aug 2018 14:59:03 +0200
+Subject: [PATCH 1/1] Add camera key long press handling
+
+Test: launch default camera app by pressing camera key.
+
+Change-Id: I9e68032eee221c20608f0d2c491c2b308350f7f6
+---
+ core/java/android/view/KeyEvent.java          |  1 +
+ .../server/policy/PhoneWindowManager.java     | 71 ++++++++++++++++++-
+ 2 files changed, 70 insertions(+), 2 deletions(-)
+
+diff --git a/core/java/android/view/KeyEvent.java b/core/java/android/view/KeyEvent.java
+index 87dd5b47c44..8a12fcbbf8f 100644
+--- a/core/java/android/view/KeyEvent.java
++++ b/core/java/android/view/KeyEvent.java
+@@ -1935,6 +1935,7 @@ public class KeyEvent extends InputEvent implements Parcelable {
+         switch (keyCode) {
+             case KeyEvent.KEYCODE_BACK:
+             case KeyEvent.KEYCODE_MENU:
++            case KeyEvent.KEYCODE_CAMERA:
+             case KeyEvent.KEYCODE_WAKEUP:
+             case KeyEvent.KEYCODE_PAIRING:
+             case KeyEvent.KEYCODE_STEM_1:
+diff --git a/services/core/java/com/android/server/policy/PhoneWindowManager.java b/services/core/java/com/android/server/policy/PhoneWindowManager.java
+index da87b2f1994..1e4cf9cfcc6 100644
+--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
++++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
+@@ -444,6 +444,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
+     // to hold wakelocks during dispatch and eliminating the critical path.
+     volatile boolean mPowerKeyHandled;
+     volatile boolean mBackKeyHandled;
++    volatile boolean mCameraKeyHandled;
+     volatile boolean mBeganFromNonInteractive;
+     volatile int mPowerKeyPressCounter;
+     volatile boolean mEndCallKeyHandled;
+@@ -643,6 +644,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
+     private static final int MSG_NOTIFY_USER_ACTIVITY = 26;
+     private static final int MSG_RINGER_TOGGLE_CHORD = 27;
+     private static final int MSG_MOVE_DISPLAY_TO_TOP = 28;
++    private static final int MSG_CAMERA_LONG_PRESS = 29;
+ 
+     private class PolicyHandler extends Handler {
+         @Override
+@@ -735,6 +737,8 @@ public class PhoneWindowManager implements WindowManagerPolicy {
+                 case MSG_MOVE_DISPLAY_TO_TOP:
+                     mWindowManagerFuncs.moveDisplayToTop(msg.arg1);
+                     mMovingDisplayToTopKeyTriggered = false;
++                case MSG_CAMERA_LONG_PRESS:
++                    cameraLongPress((KeyEvent) msg.obj);
+                     break;
+             }
+         }
+@@ -840,6 +844,27 @@ public class PhoneWindowManager implements WindowManagerPolicy {
+         mLogger.action(MetricsProto.MetricsEvent.ACTION_HUSH_GESTURE, mRingerToggleChord);
+     }
+ 
++    private void interceptCameraKeyDown(KeyEvent event) {
++        MetricsLogger.count(mContext, "key_camera_down", 1);
++        // Reset camera key state for long press
++        mCameraKeyHandled = false;
++
++        Message msg = mHandler.obtainMessage(MSG_CAMERA_LONG_PRESS, event);
++        msg.setAsynchronous(true);
++        mHandler.sendMessageDelayed(msg,
++                ViewConfiguration.get(mContext).getDeviceGlobalActionKeyTimeout());
++    }
++
++    private boolean interceptCameraKeyUp() {
++        // Cache handled state
++        boolean handled = mCameraKeyHandled;
++
++        // Reset back long press state
++        cancelPendingCameraKeyAction();
++
++        return handled;
++    }
++
+     IStatusBarService getStatusBarService() {
+         synchronized (mServiceAquireLock) {
+             if (mStatusBarService == null) {
+@@ -1092,6 +1117,13 @@ public class PhoneWindowManager implements WindowManagerPolicy {
+         }
+     }
+ 
++    private void cancelPendingCameraKeyAction() {
++        if (!mCameraKeyHandled) {
++            mCameraKeyHandled = true;
++            mHandler.removeMessages(MSG_CAMERA_LONG_PRESS);
++        }
++    }
++
+     private void powerPress(long eventTime, boolean interactive, int count) {
+         if (mDefaultDisplayPolicy.isScreenOnEarly() && !mDefaultDisplayPolicy.isScreenOnFully()) {
+             Slog.i(TAG, "Suppressed redundant power key press while "
+@@ -1302,6 +1334,29 @@ public class PhoneWindowManager implements WindowManagerPolicy {
+         }
+     }
+ 
++    private void cameraLongPress(KeyEvent event) {
++        mCameraKeyHandled = true;
++
++        boolean keyguardActive = mKeyguardDelegate == null
++                ? false
++                : mKeyguardDelegate.isShowing();
++        Intent intent = new Intent(keyguardActive
++                ? MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA_SECURE
++                : MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA);
++        ResolveInfo resolveInfo = mContext.getPackageManager().resolveActivityAsUser(intent,
++                PackageManager.MATCH_DEFAULT_ONLY,
++                mCurrentUserId);
++        String packageToLaunch = (resolveInfo == null || resolveInfo.activityInfo == null)
++                ? null : resolveInfo.activityInfo.packageName;
++        List<ActivityManager.RunningTaskInfo> tasks =
++                mContext.getSystemService(ActivityManager.class).getRunningTasks(1);
++
++        if (packageToLaunch != null && (tasks.isEmpty() ||
++                !packageToLaunch.equals(tasks.get(0).topActivity.getPackageName()))) {
++            startActivityAsUser(intent, UserHandle.CURRENT_OR_SELF);
++        }
++    }
++
+     private void accessibilityShortcutActivated() {
+         mAccessibilityShortcutController.performAccessibilityShortcut();
+     }
+@@ -4036,6 +4091,19 @@ public class PhoneWindowManager implements WindowManagerPolicy {
+                 }
+                 break;
+             }
++            case KeyEvent.KEYCODE_CAMERA: {
++                if (down) {
++                    interceptCameraKeyDown(event);
++                } else {
++                    boolean handled = interceptCameraKeyUp();
++
++                    // Don't pass camera press to app if we've already handled it via long press
++                    if (handled) {
++                        result &= ~ACTION_PASS_TO_USER;
++                    }
++                }
++                break;
++            }
+         }
+ 
+         // Intercept the Accessibility keychord for TV (DPAD_DOWN + Back) before the keyevent is
+@@ -4149,7 +4217,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
+             case KeyEvent.KEYCODE_VOLUME_MUTE:
+                 return mDefaultDisplayPolicy.getDockMode() != Intent.EXTRA_DOCK_STATE_UNDOCKED;
+ 
+-            // ignore media and camera keys
++            // ignore media keys
+             case KeyEvent.KEYCODE_MUTE:
+             case KeyEvent.KEYCODE_HEADSETHOOK:
+             case KeyEvent.KEYCODE_MEDIA_PLAY:
+@@ -4162,7 +4230,6 @@ public class PhoneWindowManager implements WindowManagerPolicy {
+             case KeyEvent.KEYCODE_MEDIA_RECORD:
+             case KeyEvent.KEYCODE_MEDIA_FAST_FORWARD:
+             case KeyEvent.KEYCODE_MEDIA_AUDIO_TRACK:
+-            case KeyEvent.KEYCODE_CAMERA:
+                 return false;
+         }
+         return true;
+-- 
+2.23.0
+

--- a/hardware/nxp/nfc/0001-hardware-nxp-Restore-pn548-support.patch
+++ b/hardware/nxp/nfc/0001-hardware-nxp-Restore-pn548-support.patch
@@ -1,0 +1,207 @@
+From a49a2b64f272bb1e559e8ac0ea1e219b111f75b0 Mon Sep 17 00:00:00 2001
+From: Humberto Borba <humberos@omnirom.org>
+Date: Sat, 1 Sep 2018 20:31:54 -0300
+Subject: [PATCH 1/2] hardware: nxp: Restore pn548 support
+
+Signed-off-by: Humberto Borba <humberos@omnirom.org>
+Change-Id: Iafb0d31626d0a8b9faf22f5307ac8b0a5a9ded37
+---
+ extns/impl/Nxp_Features.h        | 12 +++++++++
+ halimpl/dnld/phDnldNfc.cc        |  3 ++-
+ halimpl/dnld/phDnldNfc.h         |  3 +++
+ halimpl/dnld/phNxpNciHal_Dnld.cc |  3 ++-
+ halimpl/hal/phNxpNciHal.cc       |  4 +++
+ halimpl/hal/phNxpNciHal.h        |  1 +
+ halimpl/hal/phNxpNciHal_ext.cc   | 42 ++++++++++++++++++++++++++++++++
+ 7 files changed, 66 insertions(+), 2 deletions(-)
+
+diff --git a/extns/impl/Nxp_Features.h b/extns/impl/Nxp_Features.h
+index d841791..2a1529b 100755
+--- a/extns/impl/Nxp_Features.h
++++ b/extns/impl/Nxp_Features.h
+@@ -25,6 +25,7 @@
+ #define FW_MOBILE_MAJOR_NUMBER_PN81A 0x02
+ #define FW_MOBILE_MAJOR_NUMBER_PN551 0x05
+ #define FW_MOBILE_MAJOR_NUMBER_PN557 0x01
++#define FW_MOBILE_MAJOR_NUMBER_PN548 0x01
+  using namespace std;
+ typedef enum {
+   unknown,
+@@ -60,6 +61,8 @@ extern tNfc_featureList nfcFL;
+       nfcFL.chipType = pn553;                                                \
+     } else if (chipType == pn67T) {                                          \
+       nfcFL.chipType = pn551;                                                \
++    } else if (chipType == pn66T) {                                          \
++      nfcFL.chipType = pn548C2;                                              \
+     }                                                                        \
+       CONFIGURE_FEATURELIST_NFCC(chipType)                                   \
+   }
+@@ -91,6 +94,15 @@ extern tNfc_featureList nfcFL;
+       nfcFL._PHDNLDNFC_USERDATA_EEPROM_LEN = 0x0C00U;                       \
+       nfcFL._FW_MOBILE_MAJOR_NUMBER = FW_MOBILE_MAJOR_NUMBER_PN551;         \
+                                                                             \
++    } else if (chipType == pn548C2 || chipType == pn66T) {                  \
++                                                                            \
++      STRCPY_FW_LIB("libpn548_fw")                                          \
++      STRCPY_FW_BIN("pn548")                                                \
++                                                                            \
++      nfcFL._PHDNLDNFC_USERDATA_EEPROM_OFFSET = 0x02BCU;                    \
++      nfcFL._PHDNLDNFC_USERDATA_EEPROM_LEN = 0x0C00U;                       \
++      nfcFL._FW_MOBILE_MAJOR_NUMBER = FW_MOBILE_MAJOR_NUMBER_PN548;         \
++                                                                            \
+     }                                                                       \
+   }
+ #define STRCPY_FW_LIB(str) {                                                \
+diff --git a/halimpl/dnld/phDnldNfc.cc b/halimpl/dnld/phDnldNfc.cc
+index 5ee2aac..e538e40 100644
+--- a/halimpl/dnld/phDnldNfc.cc
++++ b/halimpl/dnld/phDnldNfc.cc
+@@ -248,7 +248,8 @@ NFCSTATUS phDnldNfc_CheckIntegrity(uint8_t bChipVer, pphDnldNfc_Buff_t pCRCData,
+           (((nfcFL.chipType == pn553) || (nfcFL.chipType == pn557)) &&
+            ((PHDNLDNFC_HWVER_PN553_MRA1_0 == bChipVer) ||
+             (PHDNLDNFC_HWVER_PN553_MRA1_0_UPDATED & bChipVer) ||
+-            (PHDNLDNFC_HWVER_PN557_MRA1_0 == bChipVer)))) {
++            (PHDNLDNFC_HWVER_PN557_MRA1_0 == bChipVer))) ||
++          (PHDNLDNFC_HWVER_PN548AD_MRA1_0 == bChipVer)) {
+         (gpphDnldContext->FrameInp.Type) = phDnldNfc_ChkIntg;
+       } else {
+         (gpphDnldContext->FrameInp.Type) = phDnldNfc_FTNone;
+diff --git a/halimpl/dnld/phDnldNfc.h b/halimpl/dnld/phDnldNfc.h
+index ae672ef..5950604 100755
+--- a/halimpl/dnld/phDnldNfc.h
++++ b/halimpl/dnld/phDnldNfc.h
+@@ -43,6 +43,9 @@ typedef void (*pphDnldNfc_RspCb_t)(void* pContext, NFCSTATUS wStatus,
+ #define PHDNLDNFC_HWVER_MRA2_1 (0x04U) /* ChipVersion MRA2.1 */
+ #define PHDNLDNFC_HWVER_MRA2_2 (0x05U) /* ChipVersion MRA2.2 */
+ 
++/* PN548AD ChipVersion MRA1.0 */
++#define PHDNLDNFC_HWVER_PN548AD_MRA1_0 (0x08U)
++
+ /* PN551 ChipVersion MRA1.0 */
+ #define PHDNLDNFC_HWVER_PN551_MRA1_0 (0x08U)
+ /* PN553-NCI1.0 ChipVersion MRA1.0 */
+diff --git a/halimpl/dnld/phNxpNciHal_Dnld.cc b/halimpl/dnld/phNxpNciHal_Dnld.cc
+index ceca050..6ac1890 100644
+--- a/halimpl/dnld/phNxpNciHal_Dnld.cc
++++ b/halimpl/dnld/phNxpNciHal_Dnld.cc
+@@ -524,7 +524,8 @@ static void phNxpNciHal_fw_dnld_get_version_cb(void* pContext, NFCSTATUS status,
+       if ((PHDNLDNFC_HWVER_MRA2_1 == bHwVer) ||
+           (PHDNLDNFC_HWVER_MRA2_2 == bHwVer) ||
+           ((nfcFL.chipType == pn551) &&
+-           (PHDNLDNFC_HWVER_PN551_MRA1_0 == bHwVer)) ||
++           ((PHDNLDNFC_HWVER_PN551_MRA1_0 == bHwVer) ||
++           (PHDNLDNFC_HWVER_PN548AD_MRA1_0 == bHwVer))) ||
+           (((nfcFL.chipType == pn553) || (nfcFL.chipType == pn557)) &&
+            (PHDNLDNFC_HWVER_PN553_MRA1_0 == bHwVer ||
+             PHDNLDNFC_HWVER_PN553_MRA1_0_UPDATED & pRespBuff->pBuff[0]))) {
+diff --git a/halimpl/hal/phNxpNciHal.cc b/halimpl/hal/phNxpNciHal.cc
+index 7db2a58..321da5a 100755
+--- a/halimpl/hal/phNxpNciHal.cc
++++ b/halimpl/hal/phNxpNciHal.cc
+@@ -822,6 +822,10 @@ int phNxpNciHal_fw_mw_ver_check() {
+              (rom_version == FW_MOBILE_ROM_VERSION_PN551) &&
+              (fw_maj_ver == 0x05)) {
+     status = NFCSTATUS_SUCCESS;
++  } else if (((nfcFL.chipType == pn548C2) || (nfcFL.chipType == pn66T)) &&
++             (rom_version == FW_MOBILE_ROM_VERSION_PN548) &&
++             (fw_maj_ver == 0x01)) {
++    status = NFCSTATUS_SUCCESS;
+   }
+   return status;
+ }
+diff --git a/halimpl/hal/phNxpNciHal.h b/halimpl/hal/phNxpNciHal.h
+index 5e59dce..7389f2c 100755
+--- a/halimpl/hal/phNxpNciHal.h
++++ b/halimpl/hal/phNxpNciHal.h
+@@ -36,6 +36,7 @@ typedef void(phNxpNciHal_control_granted_callback_t)();
+ #define FW_MOBILE_ROM_VERSION_PN551 0x10
+ #define FW_MOBILE_ROM_VERSION_PN553 0x11
+ #define FW_MOBILE_ROM_VERSION_PN557 0x12
++#define FW_MOBILE_ROM_VERSION_PN548 0x10
+ /* NCI Data */
+ 
+ #define NCI_MT_CMD 0x20
+diff --git a/halimpl/hal/phNxpNciHal_ext.cc b/halimpl/hal/phNxpNciHal_ext.cc
+index 9daa662..1fe6f49 100755
+--- a/halimpl/hal/phNxpNciHal_ext.cc
++++ b/halimpl/hal/phNxpNciHal_ext.cc
+@@ -36,6 +36,7 @@ extern uint32_t cleanup_timer;
+ extern bool nfc_debug_enabled;
+ uint8_t icode_detected = 0x00;
+ uint8_t icode_send_eof = 0x00;
++uint8_t nfcdep_detected = 0x00;
+ static uint8_t ee_disc_done = 0x00;
+ uint8_t EnableP2P_PrioLogic = false;
+ static uint32_t RfDiscID = 1;
+@@ -144,6 +145,12 @@ NFCSTATUS phNxpNciHal_process_ext_rsp(uint8_t* p_ntf, uint16_t* p_len) {
+ 
+   if (p_ntf[0] == 0x61 && p_ntf[1] == 0x05) {
+ 
++    if (nfcFL.chipType == pn548C2) {
++      if (nfcdep_detected) {
++        nfcdep_detected = 0x00;
++      }
++    }
++
+     switch (p_ntf[4]) {
+       case 0x00:
+         NXPLOG_NCIHAL_D("NxpNci: RF Interface = NFCEE Direct RF");
+@@ -156,6 +163,9 @@ NFCSTATUS phNxpNciHal_process_ext_rsp(uint8_t* p_ntf, uint16_t* p_len) {
+         break;
+       case 0x03:
+         NXPLOG_NCIHAL_D("NxpNci: RF Interface = NFC-DEP");
++        if (nfcFL.chipType == pn548C2) {
++          nfcdep_detected = 0x01;
++        }
+         break;
+       case 0x80:
+         NXPLOG_NCIHAL_D("NxpNci: RF Interface = MIFARE");
+@@ -445,6 +455,14 @@ static NFCSTATUS phNxpNciHal_ext_process_nfc_init_rsp(uint8_t* p_ntf,
+       }
+       NXPLOG_NCIHAL_D("CORE_RESET_NTF received !");
+       NXPLOG_NCIR_E("len = %3d > %s", *p_len, print_buffer);
++      if (nfcFL.chipType == pn548C2 && nfcdep_detected &&
++          !(p_ntf[2] == 0x06 && p_ntf[3] == 0xA0 && p_ntf[4] == 0x00 &&
++            ((p_ntf[5] == 0xC9 && p_ntf[6] == 0x95 && p_ntf[7] == 0x00 &&
++              p_ntf[8] == 0x00) ||
++             (p_ntf[5] == 0x07 && p_ntf[6] == 0x39 && p_ntf[7] == 0xF2 &&
++              p_ntf[8] == 0x00)))) {
++        nfcdep_detected = 0x00;
++      }
+       phNxpNciHal_emergency_recovery();
+       status = NFCSTATUS_FAILED;
+     } /* Parsing CORE_INIT_RSP*/
+@@ -861,6 +879,30 @@ NFCSTATUS phNxpNciHal_write_ext(uint16_t* cmd_len, uint8_t* p_cmd_data,
+     }
+   }
+ 
++  if (nfcFL.chipType == pn548C2) {
++    if (p_cmd_data[0] == 0x20 && p_cmd_data[1] == 0x02) {
++       uint8_t temp;
++       uint8_t* p = p_cmd_data + 4;
++       uint8_t* end = p_cmd_data + *cmd_len;
++       while (p < end) {
++         if (*p == 0x53)  // LF_T3T_FLAGS
++         {
++           NXPLOG_NCIHAL_D("> Going through workaround - LF_T3T_FLAGS swap");
++           temp = *(p + 3);
++           *(p + 3) = *(p + 2);
++           *(p + 2) = temp;
++           NXPLOG_NCIHAL_D("> Going through workaround - LF_T3T_FLAGS - End");
++           status = NFCSTATUS_SUCCESS;
++           break;
++         }
++         if (*p == 0xA0) {
++           p += *(p + 2) + 3;
++         } else {
++           p += *(p + 1) + 2;
++         }
++       }
++     }
++  }
+ 
+   return status;
+ }
+-- 
+2.23.0
+

--- a/hardware/nxp/nfc/0002-hardware-nxp-Restore-pn547-support.patch
+++ b/hardware/nxp/nfc/0002-hardware-nxp-Restore-pn547-support.patch
@@ -1,0 +1,475 @@
+From bb3627360dbb6ead654f2b97ea6e9b81d9f39393 Mon Sep 17 00:00:00 2001
+From: Humberto Borba <humberos@omnirom.org>
+Date: Sat, 1 Sep 2018 21:24:56 -0300
+Subject: [PATCH 2/2] hardware: nxp: Restore pn547 support
+
+Change-Id: I498367f676f8c8d7fc13e849509d0d8a05ec89a8
+Signed-off-by: Humberto Borba <humberos@omnirom.org>
+---
+ extns/impl/Nxp_Features.h          |  12 ++
+ halimpl/dnld/phDnldNfc.cc          |   6 +-
+ halimpl/dnld/phNxpNciHal_Dnld.cc   |   2 +-
+ halimpl/hal/phNxpNciHal.cc         | 172 ++++++++++++++++-------------
+ halimpl/hal/phNxpNciHal.h          |   1 +
+ halimpl/hal/phNxpNciHal_ext.cc     |  20 +++-
+ halimpl/utils/NxpNfcCapability.cpp |   4 +
+ 7 files changed, 135 insertions(+), 82 deletions(-)
+
+diff --git a/extns/impl/Nxp_Features.h b/extns/impl/Nxp_Features.h
+index 2a1529b..c060794 100755
+--- a/extns/impl/Nxp_Features.h
++++ b/extns/impl/Nxp_Features.h
+@@ -26,6 +26,7 @@
+ #define FW_MOBILE_MAJOR_NUMBER_PN551 0x05
+ #define FW_MOBILE_MAJOR_NUMBER_PN557 0x01
+ #define FW_MOBILE_MAJOR_NUMBER_PN548 0x01
++#define FW_MOBILE_MAJOR_NUMBER_PN547 0x01
+  using namespace std;
+ typedef enum {
+   unknown,
+@@ -63,6 +64,8 @@ extern tNfc_featureList nfcFL;
+       nfcFL.chipType = pn551;                                                \
+     } else if (chipType == pn66T) {                                          \
+       nfcFL.chipType = pn548C2;                                              \
++    } else if (chipType == pn65T) {                                          \
++      nfcFL.chipType = pn547C2;                                              \
+     }                                                                        \
+       CONFIGURE_FEATURELIST_NFCC(chipType)                                   \
+   }
+@@ -103,6 +106,15 @@ extern tNfc_featureList nfcFL;
+       nfcFL._PHDNLDNFC_USERDATA_EEPROM_LEN = 0x0C00U;                       \
+       nfcFL._FW_MOBILE_MAJOR_NUMBER = FW_MOBILE_MAJOR_NUMBER_PN548;         \
+                                                                             \
++    } else if (chipType == pn547C2 || chipType == pn65T) {                  \
++                                                                            \
++      STRCPY_FW_LIB("libpn547_fw")                                          \
++      STRCPY_FW_BIN("pn547")                                                \
++                                                                            \
++      nfcFL._PHDNLDNFC_USERDATA_EEPROM_OFFSET = 0x023CU;                    \
++      nfcFL._PHDNLDNFC_USERDATA_EEPROM_LEN = 0x0C80U;                       \
++      nfcFL._FW_MOBILE_MAJOR_NUMBER = FW_MOBILE_MAJOR_NUMBER_PN547;         \
++                                                                            \
+     }                                                                       \
+   }
+ #define STRCPY_FW_LIB(str) {                                                \
+diff --git a/halimpl/dnld/phDnldNfc.cc b/halimpl/dnld/phDnldNfc.cc
+index e538e40..a010d89 100644
+--- a/halimpl/dnld/phDnldNfc.cc
++++ b/halimpl/dnld/phDnldNfc.cc
+@@ -752,7 +752,7 @@ NFCSTATUS phDnldNfc_InitImgInfo(void) {
+     wStatus = phDnldNfc_LoadBinFW(&pImageInfo, &ImageInfoLen);
+   } else if(fwType == FW_FORMAT_SO) {
+     gpphDnldContext->FwFormat = FW_FORMAT_SO;
+-    if (gRecFWDwnld == true) {
++    if ((gRecFWDwnld == true) && (nfcFL.chipType != pn547C2)) {
+       wStatus = phDnldNfc_LoadRecoveryFW(&pImageInfo, &ImageInfoLen);
+     } else {
+       wStatus = phDnldNfc_LoadFW(&pImageInfo, &ImageInfoLen);
+@@ -828,7 +828,7 @@ NFCSTATUS phDnldNfc_LoadRecInfo(void) {
+   /* if memory is not allocated then allocate memory for donwload context
+    * structure */
+   phDnldNfc_SetHwDevHandle();
+-  if (gRecFWDwnld == true)
++  if ((gRecFWDwnld == true) && (nfcFL.chipType != pn547C2))
+     wStatus = phDnldNfc_LoadRecoveryFW(&pImageInfo, &ImageInfoLen);
+   else
+     wStatus = phDnldNfc_LoadFW(&pImageInfo, &ImageInfoLen);
+@@ -884,7 +884,7 @@ NFCSTATUS phDnldNfc_LoadPKInfo(void) {
+    * structure */
+   phDnldNfc_SetHwDevHandle();
+   /* load the PKU image library */
+-  if (gRecFWDwnld == true)
++  if ((gRecFWDwnld == true) && (nfcFL.chipType != pn547C2))
+     wStatus = phDnldNfc_LoadRecoveryFW(&pImageInfo, &ImageInfoLen);
+   else
+     wStatus = phDnldNfc_LoadFW(&pImageInfo, &ImageInfoLen);
+diff --git a/halimpl/dnld/phNxpNciHal_Dnld.cc b/halimpl/dnld/phNxpNciHal_Dnld.cc
+index 6ac1890..a71b8fd 100644
+--- a/halimpl/dnld/phNxpNciHal_Dnld.cc
++++ b/halimpl/dnld/phNxpNciHal_Dnld.cc
+@@ -1699,7 +1699,7 @@ NFCSTATUS phNxpNciHal_fw_download_seq(uint8_t bClkSrcVal, uint8_t bClkFreqVal) {
+   /* Get firmware version */
+   if (NFCSTATUS_SUCCESS == phDnldNfc_InitImgInfo()) {
+     NXPLOG_FWDNLD_D("phDnldNfc_InitImgInfo:SUCCESS");
+-    if (gRecFWDwnld == true) {
++    if ((gRecFWDwnld == true) && (nfcFL.chipType != pn547C2)) {
+       status =
+           phNxpNciHal_fw_seq_handler(phNxpNciHal_dummy_rec_dwnld_seqhandler);
+     } else {
+diff --git a/halimpl/hal/phNxpNciHal.cc b/halimpl/hal/phNxpNciHal.cc
+index 321da5a..54f853f 100755
+--- a/halimpl/hal/phNxpNciHal.cc
++++ b/halimpl/hal/phNxpNciHal.cc
+@@ -458,7 +458,7 @@ static NFCSTATUS phNxpNciHal_CheckValidFwVersion(void) {
+       }
+     }
+   }
+-  else if (gRecFWDwnld == TRUE) {
++  else if ((gRecFWDwnld == TRUE) && (nfcFL.chipType != pn547C2)) {
+     status = NFCSTATUS_SUCCESS;
+   }
+   else if (wFwVerRsp == 0) {
+@@ -826,6 +826,10 @@ int phNxpNciHal_fw_mw_ver_check() {
+              (rom_version == FW_MOBILE_ROM_VERSION_PN548) &&
+              (fw_maj_ver == 0x01)) {
+     status = NFCSTATUS_SUCCESS;
++  } else if (((nfcFL.chipType == pn547C2) || (nfcFL.chipType == pn65T)) &&
++             (rom_version == FW_MOBILE_ROM_VERSION_PN547) &&
++             (fw_maj_ver == 0x01)) {
++    status = NFCSTATUS_SUCCESS;
+   }
+   return status;
+ }
+@@ -1392,54 +1396,58 @@ int phNxpNciHal_core_initialized(uint8_t* p_core_init_rsp_params) {
+       if(num != 0) phNxpNciHal_phase_tirm_offset_sign_update();
+     }
+ 
+-    NXPLOG_NCIHAL_D("Performing TVDD Settings");
+-    isfound = GetNxpNumValue(NAME_NXP_EXT_TVDD_CFG, &num, sizeof(num));
+-    if (isfound > 0) {
+-      if (num == 1) {
+-        isfound = GetNxpByteArrayValue(NAME_NXP_EXT_TVDD_CFG_1, (char*)buffer,
+-                                       bufflen, &retlen);
+-        if (retlen > 0) {
+-          status = phNxpNciHal_send_ext_cmd(retlen, buffer);
+-          if (status != NFCSTATUS_SUCCESS) {
+-            NXPLOG_NCIHAL_E("EXT TVDD CFG 1 Settings failed");
+-            retry_core_init_cnt++;
+-            goto retry_core_init;
++    if (nfcFL.chipType != pn547C2) {
++      NXPLOG_NCIHAL_D("Performing TVDD Settings");
++      isfound = GetNxpNumValue(NAME_NXP_EXT_TVDD_CFG, &num, sizeof(num));
++      if (isfound > 0) {
++        if (num == 1) {
++          isfound = GetNxpByteArrayValue(NAME_NXP_EXT_TVDD_CFG_1, (char*)buffer,
++                                         bufflen, &retlen);
++          if (retlen > 0) {
++            status = phNxpNciHal_send_ext_cmd(retlen, buffer);
++            if (status != NFCSTATUS_SUCCESS) {
++              NXPLOG_NCIHAL_E("EXT TVDD CFG 1 Settings failed");
++              retry_core_init_cnt++;
++              goto retry_core_init;
++            }
+           }
+-        }
+-      } else if (num == 2) {
+-        isfound = GetNxpByteArrayValue(NAME_NXP_EXT_TVDD_CFG_2, (char*)buffer,
+-                                       bufflen, &retlen);
+-        if (retlen > 0) {
+-          status = phNxpNciHal_send_ext_cmd(retlen, buffer);
+-          if (status != NFCSTATUS_SUCCESS) {
+-            NXPLOG_NCIHAL_E("EXT TVDD CFG 2 Settings failed");
+-            retry_core_init_cnt++;
+-            goto retry_core_init;
++        } else if (num == 2) {
++          isfound = GetNxpByteArrayValue(NAME_NXP_EXT_TVDD_CFG_2, (char*)buffer,
++                                         bufflen, &retlen);
++          if (retlen > 0) {
++            status = phNxpNciHal_send_ext_cmd(retlen, buffer);
++            if (status != NFCSTATUS_SUCCESS) {
++              NXPLOG_NCIHAL_E("EXT TVDD CFG 2 Settings failed");
++              retry_core_init_cnt++;
++              goto retry_core_init;
++            }
+           }
+-        }
+-      } else if (num == 3) {
+-        isfound = GetNxpByteArrayValue(NAME_NXP_EXT_TVDD_CFG_3, (char*)buffer,
+-                                       bufflen, &retlen);
+-        if (retlen > 0) {
+-          status = phNxpNciHal_send_ext_cmd(retlen, buffer);
+-          if (status != NFCSTATUS_SUCCESS) {
+-            NXPLOG_NCIHAL_E("EXT TVDD CFG 3 Settings failed");
+-            retry_core_init_cnt++;
+-            goto retry_core_init;
++        } else if (num == 3) {
++          isfound = GetNxpByteArrayValue(NAME_NXP_EXT_TVDD_CFG_3, (char*)buffer,
++                                         bufflen, &retlen);
++          if (retlen > 0) {
++            status = phNxpNciHal_send_ext_cmd(retlen, buffer);
++            if (status != NFCSTATUS_SUCCESS) {
++              NXPLOG_NCIHAL_E("EXT TVDD CFG 3 Settings failed");
++              retry_core_init_cnt++;
++              goto retry_core_init;
++            }
+           }
++        } else {
++          NXPLOG_NCIHAL_E("Wrong Configuration Value %ld", num);
+         }
+-      } else {
+-        NXPLOG_NCIHAL_E("Wrong Configuration Value %ld", num);
+       }
+     }
+     retlen = 0;
+-    config_access = false;
++    if (nfcFL.chipType != pn547C2) {
++      config_access = false;
++    }
+     NXPLOG_NCIHAL_D("Performing RF Settings BLK 1");
+     isfound = GetNxpByteArrayValue(NAME_NXP_RF_CONF_BLK_1, (char*)buffer,
+                                    bufflen, &retlen);
+     if (retlen > 0) {
+       status = phNxpNciHal_send_ext_cmd(retlen, buffer);
+-      if (status == NFCSTATUS_SUCCESS) {
++      if ((status == NFCSTATUS_SUCCESS) && (nfcFL.chipType != pn547C2)) {
+         status = phNxpNciHal_CheckRFCmdRespStatus();
+         /*STATUS INVALID PARAM 0x09*/
+         if (status == 0x09) {
+@@ -1461,7 +1469,7 @@ int phNxpNciHal_core_initialized(uint8_t* p_core_init_rsp_params) {
+                                    bufflen, &retlen);
+     if (retlen > 0) {
+       status = phNxpNciHal_send_ext_cmd(retlen, buffer);
+-      if (status == NFCSTATUS_SUCCESS) {
++      if ((status == NFCSTATUS_SUCCESS) && (nfcFL.chipType != pn547C2)) {
+         status = phNxpNciHal_CheckRFCmdRespStatus();
+         /*STATUS INVALID PARAM 0x09*/
+         if (status == 0x09) {
+@@ -1483,7 +1491,7 @@ int phNxpNciHal_core_initialized(uint8_t* p_core_init_rsp_params) {
+                                    bufflen, &retlen);
+     if (retlen > 0) {
+       status = phNxpNciHal_send_ext_cmd(retlen, buffer);
+-      if (status == NFCSTATUS_SUCCESS) {
++      if ((status == NFCSTATUS_SUCCESS) && (nfcFL.chipType != pn547C2)) {
+         status = phNxpNciHal_CheckRFCmdRespStatus();
+         /*STATUS INVALID PARAM 0x09*/
+         if (status == 0x09) {
+@@ -1505,7 +1513,7 @@ int phNxpNciHal_core_initialized(uint8_t* p_core_init_rsp_params) {
+                                    bufflen, &retlen);
+     if (retlen > 0) {
+       status = phNxpNciHal_send_ext_cmd(retlen, buffer);
+-      if (status == NFCSTATUS_SUCCESS) {
++      if ((status == NFCSTATUS_SUCCESS) && (nfcFL.chipType != pn547C2)) {
+         status = phNxpNciHal_CheckRFCmdRespStatus();
+         /*STATUS INVALID PARAM 0x09*/
+         if (status == 0x09) {
+@@ -1527,7 +1535,7 @@ int phNxpNciHal_core_initialized(uint8_t* p_core_init_rsp_params) {
+                                    bufflen, &retlen);
+     if (retlen > 0) {
+       status = phNxpNciHal_send_ext_cmd(retlen, buffer);
+-      if (status == NFCSTATUS_SUCCESS) {
++      if ((status == NFCSTATUS_SUCCESS) && (nfcFL.chipType != pn547C2)) {
+         status = phNxpNciHal_CheckRFCmdRespStatus();
+         /*STATUS INVALID PARAM 0x09*/
+         if (status == 0x09) {
+@@ -1549,7 +1557,7 @@ int phNxpNciHal_core_initialized(uint8_t* p_core_init_rsp_params) {
+                                    bufflen, &retlen);
+     if (retlen > 0) {
+       status = phNxpNciHal_send_ext_cmd(retlen, buffer);
+-      if (status == NFCSTATUS_SUCCESS) {
++      if ((status == NFCSTATUS_SUCCESS) && (nfcFL.chipType != pn547C2)) {
+         status = phNxpNciHal_CheckRFCmdRespStatus();
+         /*STATUS INVALID PARAM 0x09*/
+         if (status == 0x09) {
+@@ -1565,7 +1573,9 @@ int phNxpNciHal_core_initialized(uint8_t* p_core_init_rsp_params) {
+       }
+     }
+     retlen = 0;
+-    config_access = true;
++    if (nfcFL.chipType != pn547C2) {
++        config_access = true;
++    }
+     NXPLOG_NCIHAL_D("Performing NAME_NXP_CORE_CONF_EXTN Settings");
+     isfound = GetNxpByteArrayValue(NAME_NXP_CORE_CONF_EXTN, (char*)buffer,
+                                    bufflen, &retlen);
+@@ -1593,13 +1603,15 @@ int phNxpNciHal_core_initialized(uint8_t* p_core_init_rsp_params) {
+     }
+ 
+     retlen = 0;
+-    config_access = false;
++    if (nfcFL.chipType != pn547C2) {
++      config_access = false;
++    }
+     isfound = GetNxpByteArrayValue(NAME_NXP_CORE_RF_FIELD, (char*)buffer,
+                                    bufflen, &retlen);
+     if (retlen > 0) {
+       /* NXP ACT Proprietary Ext */
+       status = phNxpNciHal_send_ext_cmd(retlen, buffer);
+-      if (status == NFCSTATUS_SUCCESS) {
++      if ((status == NFCSTATUS_SUCCESS) && (nfcFL.chipType != pn547C2)) {
+         status = phNxpNciHal_CheckRFCmdRespStatus();
+         /*STATUS INVALID PARAM 0x09*/
+         if (status == 0x09) {
+@@ -1614,42 +1626,46 @@ int phNxpNciHal_core_initialized(uint8_t* p_core_init_rsp_params) {
+         goto retry_core_init;
+       }
+     }
+-    config_access = true;
++    if (nfcFL.chipType != pn547C2) {
++      config_access = true;
++    }
+ 
+     retlen = 0;
+-    /* NXP SWP switch timeout Setting*/
+-    if (GetNxpNumValue(NAME_NXP_SWP_SWITCH_TIMEOUT, (void*)&retlen,
+-                       sizeof(retlen))) {
+-      // Check the permissible range [0 - 60]
+-      if (0 <= retlen && retlen <= 60) {
+-        if (0 < retlen) {
+-          unsigned int timeout = retlen * 1000;
+-          unsigned int timeoutHx = 0x0000;
+-
+-          char tmpbuffer[10] = {0};
+-          snprintf((char*)tmpbuffer, 10, "%04x", timeout);
+-          sscanf((char*)tmpbuffer, "%x", &timeoutHx);
+-
+-          swp_switch_timeout_cmd[7] = (timeoutHx & 0xFF);
+-          swp_switch_timeout_cmd[8] = ((timeoutHx & 0xFF00) >> 8);
+-        }
++    if (nfcFL.chipType != pn547C2) {
++      /* NXP SWP switch timeout Setting*/
++      if (GetNxpNumValue(NAME_NXP_SWP_SWITCH_TIMEOUT, (void*)&retlen,
++                         sizeof(retlen))) {
++        // Check the permissible range [0 - 60]
++        if (0 <= retlen && retlen <= 60) {
++          if (0 < retlen) {
++            unsigned int timeout = retlen * 1000;
++            unsigned int timeoutHx = 0x0000;
++
++            char tmpbuffer[10] = {0};
++            snprintf((char*)tmpbuffer, 10, "%04x", timeout);
++            sscanf((char*)tmpbuffer, "%x", &timeoutHx);
++
++            swp_switch_timeout_cmd[7] = (timeoutHx & 0xFF);
++            swp_switch_timeout_cmd[8] = ((timeoutHx & 0xFF00) >> 8);
++          }
+ 
+-        status = phNxpNciHal_send_ext_cmd(sizeof(swp_switch_timeout_cmd),
+-                                          swp_switch_timeout_cmd);
+-        if (status != NFCSTATUS_SUCCESS) {
+-          NXPLOG_NCIHAL_E("SWP switch timeout Setting Failed");
+-          retry_core_init_cnt++;
+-          goto retry_core_init;
++          status = phNxpNciHal_send_ext_cmd(sizeof(swp_switch_timeout_cmd),
++                                            swp_switch_timeout_cmd);
++          if (status != NFCSTATUS_SUCCESS) {
++            NXPLOG_NCIHAL_E("SWP switch timeout Setting Failed");
++            retry_core_init_cnt++;
++            goto retry_core_init;
++          }
++        } else {
++          NXPLOG_NCIHAL_E("SWP switch timeout Setting Failed - out of range!");
+         }
+-      } else {
+-        NXPLOG_NCIHAL_E("SWP switch timeout Setting Failed - out of range!");
+       }
+-    }
+ 
+-    status = phNxpNciHal_china_tianjin_rf_setting();
+-    if (status != NFCSTATUS_SUCCESS) {
+-      NXPLOG_NCIHAL_E("phNxpNciHal_china_tianjin_rf_setting failed");
+-      return NFCSTATUS_FAILED;
++      status = phNxpNciHal_china_tianjin_rf_setting();
++      if (status != NFCSTATUS_SUCCESS) {
++        NXPLOG_NCIHAL_E("phNxpNciHal_china_tianjin_rf_setting failed");
++        return NFCSTATUS_FAILED;
++      }
+     }
+     // Update eeprom value
+     status = phNxpNciHal_set_mw_eeprom();
+@@ -1867,8 +1883,10 @@ int phNxpNciHal_core_initialized(uint8_t* p_core_init_rsp_params) {
+     buffer = NULL;
+   }
+   // initialize dummy FW recovery variables
+-  gRecFWDwnld = 0;
+-  gRecFwRetryCount = 0;
++  if (nfcFL.chipType != pn547C2) {
++    gRecFWDwnld = 0;
++    gRecFwRetryCount = 0;
++  }
+   if (!((*p_core_init_rsp_params > 0) && (*p_core_init_rsp_params < 4)))
+     phNxpNciHal_core_initialized_complete(status);
+   else {
+diff --git a/halimpl/hal/phNxpNciHal.h b/halimpl/hal/phNxpNciHal.h
+index 7389f2c..776fa24 100755
+--- a/halimpl/hal/phNxpNciHal.h
++++ b/halimpl/hal/phNxpNciHal.h
+@@ -37,6 +37,7 @@ typedef void(phNxpNciHal_control_granted_callback_t)();
+ #define FW_MOBILE_ROM_VERSION_PN553 0x11
+ #define FW_MOBILE_ROM_VERSION_PN557 0x12
+ #define FW_MOBILE_ROM_VERSION_PN548 0x10
++#define FW_MOBILE_ROM_VERSION_PN547 0x08
+ /* NCI Data */
+ 
+ #define NCI_MT_CMD 0x20
+diff --git a/halimpl/hal/phNxpNciHal_ext.cc b/halimpl/hal/phNxpNciHal_ext.cc
+index 1fe6f49..d1591fa 100755
+--- a/halimpl/hal/phNxpNciHal_ext.cc
++++ b/halimpl/hal/phNxpNciHal_ext.cc
+@@ -96,6 +96,7 @@ void phNxpNciHal_ext_init(void) {
+ *******************************************************************************/
+ NFCSTATUS phNxpNciHal_process_ext_rsp(uint8_t* p_ntf, uint16_t* p_len) {
+   NFCSTATUS status = NFCSTATUS_SUCCESS;
++  uint16_t rf_technology_length_param = 0;
+ 
+   if (p_ntf[0] == 0x61 && p_ntf[1] == 0x05 && *p_len < 14) {
+     if(*p_len <= 6) {
+@@ -198,6 +199,7 @@ NFCSTATUS phNxpNciHal_process_ext_rsp(uint8_t* p_ntf, uint16_t* p_len) {
+       case 0x80:
+         NXPLOG_NCIHAL_D("NxpNci: Protocol = MIFARE");
+         break;
++      case 0x8A:
+       case 0x81:
+         NXPLOG_NCIHAL_D("NxpNci: Protocol = Kovio");
+         break;
+@@ -225,6 +227,7 @@ NFCSTATUS phNxpNciHal_process_ext_rsp(uint8_t* p_ntf, uint16_t* p_len) {
+       case 0x06:
+         NXPLOG_NCIHAL_D("NxpNci: Mode = 15693 Passive Poll");
+         break;
++      case 0x77:
+       case 0x70:
+         NXPLOG_NCIHAL_D("NxpNci: Mode = Kovio");
+         break;
+@@ -318,6 +321,15 @@ NFCSTATUS phNxpNciHal_process_ext_rsp(uint8_t* p_ntf, uint16_t* p_len) {
+   } else if (p_ntf[0] == 0x41 && p_ntf[1] == 0x04 && cleanup_timer != 0) {
+     status = NFCSTATUS_FAILED;
+     return status;
++  } else if (p_ntf[0] == 0x61 && p_ntf[1] == 0x05 && p_ntf[4] == 0x02 &&
++        p_ntf[5] == 0x80 && p_ntf[6] == 0x00 && nfcFL.chipType == pn547C2) {
++    NXPLOG_NCIHAL_D(
++        "Going through workaround - iso-dep  interface  mifare protocol with "
++        "sak value not equal to 0x20");
++    rf_technology_length_param = p_ntf[9];
++    if ((p_ntf[9 + rf_technology_length_param] & 0x20) != 0x20) {
++      p_ntf[4] = 0x80;
++    }
+   }
+   else if (*p_len == 4 && p_ntf[0] == 0x4F && p_ntf[1] == 0x11 &&
+            p_ntf[2] == 0x01) {
+@@ -693,12 +705,18 @@ NFCSTATUS phNxpNciHal_write_ext(uint16_t* cmd_len, uint8_t* p_cmd_data,
+     if (nxpncihal_ctrl.nci_info.nci_version != NCI_VERSION_2_0) {
+       NXPLOG_NCIHAL_D("> Going through workaround - set host list");
+ 
++    if (nfcFL.chipType == pn547C2) {
++      *cmd_len = 7;
++
++       p_cmd_data[2] = 0x04;
++       p_cmd_data[6] = 0xC0;
++    } else {
+       *cmd_len = 8;
+ 
+       p_cmd_data[2] = 0x05;
+       p_cmd_data[6] = 0x02;
+       p_cmd_data[7] = 0xC0;
+-
++    }
+       NXPLOG_NCIHAL_D("> Going through workaround - set host list - END");
+       status = NFCSTATUS_SUCCESS;
+     }
+diff --git a/halimpl/utils/NxpNfcCapability.cpp b/halimpl/utils/NxpNfcCapability.cpp
+index 720ed08..51752ca 100644
+--- a/halimpl/utils/NxpNfcCapability.cpp
++++ b/halimpl/utils/NxpNfcCapability.cpp
+@@ -92,6 +92,10 @@ tNFC_chipType capability::getChipType(uint8_t* msg, uint16_t msg_len) {
+           chipType = pn548C2;
+           break;
+ 
++        case 0x01:
++          chipType = pn547C2;
++          break;
++
+         case 0x18:
+         case 0x58:  // NQ220
+           chipType = pn66T;
+-- 
+2.23.0
+

--- a/hardware/qcom/audio/0001-hal-msm8916-Add-missing-bracket-to-close-function-de.patch
+++ b/hardware/qcom/audio/0001-hal-msm8916-Add-missing-bracket-to-close-function-de.patch
@@ -1,0 +1,28 @@
+From 736db57f744e0ea892a6df1c86a26316e24771d8 Mon Sep 17 00:00:00 2001
+From: MarijnS95 <marijns95@gmail.com>
+Date: Wed, 4 Sep 2019 15:04:44 +0200
+Subject: [PATCH 1/1] hal: msm8916: Add missing bracket to close function
+ definition.
+
+Got lost in 019d19bf1ad36c3397737869a4b105226f811889.
+
+Change-Id: I8296a8fb551097fabf72115d2cec0849671b91ea
+---
+ hal/msm8916/platform.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/hal/msm8916/platform.c b/hal/msm8916/platform.c
+index 8a517a9..41727bd 100644
+--- a/hal/msm8916/platform.c
++++ b/hal/msm8916/platform.c
+@@ -1572,6 +1572,7 @@ static int platform_get_meta_info_key_from_list(void *platform, char *mod_name)
+         }
+     }
+     return key;
++}
+ 
+ int platform_set_effect_config_data(snd_device_t snd_device,
+                                       struct audio_effect_config effect_config,
+-- 
+2.23.0
+

--- a/hardware/qcom/bootctrl/0001-Q-Never-build-bootctrl-the-old-way.patch
+++ b/hardware/qcom/bootctrl/0001-Q-Never-build-bootctrl-the-old-way.patch
@@ -1,0 +1,60 @@
+From 0dfe157012a8f9a2031d015e1d27fceca0467f43 Mon Sep 17 00:00:00 2001
+From: MarijnS95 <marijns95@gmail.com>
+Date: Mon, 9 Sep 2019 14:18:43 +0200
+Subject: [PATCH 1/1] [Q] Never build bootctrl the old way.
+
+We are moving all our platforms to build bootctrl using the BluePrint
+mechanism. Remove the makefile alltogether to prevent building bootctrl
+on unsupported platforms (msm8998 for example).
+
+Change-Id: I999da77b7bba9aca4a2f17045b6eff010aa5faf1
+Signed-off-by: MarijnS95 <marijns95@gmail.com>
+---
+ Android.mk | 35 -----------------------------------
+ 1 file changed, 35 deletions(-)
+ delete mode 100644 Android.mk
+
+diff --git a/Android.mk b/Android.mk
+deleted file mode 100644
+index c5a9b16..0000000
+--- a/Android.mk
++++ /dev/null
+@@ -1,35 +0,0 @@
+-# Preset TARGET_USES_HARDWARE_QCOM_BOOTCTRL for existing platforms.
+-ifneq ($(filter msm8996 msm8998 sdm710,$(TARGET_BOARD_PLATFORM)),)
+-TARGET_USES_HARDWARE_QCOM_BOOTCTRL := true
+-endif
+-
+-ifeq ($(strip $(TARGET_USES_HARDWARE_QCOM_BOOTCTRL)),true)
+-# TODO:  Find a better way to separate build configs for ADP vs non-ADP devices
+-ifneq ($(BOARD_IS_AUTOMOTIVE),true)
+-LOCAL_PATH := $(call my-dir)
+-
+-# HAL Shared library for the target. Used by libhardware.
+-include $(CLEAR_VARS)
+-LOCAL_C_INCLUDES += $(TARGET_OUT_HEADERS)/gpt-utils/inc
+-LOCAL_CFLAGS += -Wall -Werror
+-LOCAL_SHARED_LIBRARIES += liblog libgptutils libcutils
+-LOCAL_HEADER_LIBRARIES := libhardware_headers libsystem_headers
+-LOCAL_SRC_FILES := boot_control.cpp
+-LOCAL_MODULE_RELATIVE_PATH := hw
+-LOCAL_MODULE := bootctrl.$(TARGET_BOARD_PLATFORM)
+-LOCAL_MODULE_OWNER := qcom
+-LOCAL_PROPRIETARY_MODULE := true
+-include $(BUILD_SHARED_LIBRARY)
+-
+-# Static library for the target. Used by update_engine_sideload from recovery.
+-include $(CLEAR_VARS)
+-LOCAL_C_INCLUDES += $(TARGET_OUT_HEADERS)/gpt-utils/inc
+-LOCAL_CFLAGS += -Wall -Werror
+-LOCAL_SHARED_LIBRARIES += liblog libgptutils libcutils
+-LOCAL_HEADER_LIBRARIES := libhardware_headers libsystem_headers
+-LOCAL_SRC_FILES := boot_control.cpp
+-LOCAL_MODULE := bootctrl.$(TARGET_BOARD_PLATFORM)
+-include $(BUILD_STATIC_LIBRARY)
+-
+-endif
+-endif
+-- 
+2.23.0
+

--- a/hardware/qcom/gps/0001-set_sched_policy-was-reverted-but-invocation-still-t.patch
+++ b/hardware/qcom/gps/0001-set_sched_policy-was-reverted-but-invocation-still-t.patch
@@ -1,0 +1,26 @@
+From c15a2b124d586d6de8ef84b7a857072d198bc23b Mon Sep 17 00:00:00 2001
+From: MarijnS95 <marijns95@gmail.com>
+Date: Wed, 28 Aug 2019 17:56:18 +0200
+Subject: [PATCH 1/1] set_sched_policy was reverted, but invocation still
+ there.
+
+Change-Id: I0179922d35737c71fb2c0b4002a62da3e2395989
+---
+ sdm845/utils/MsgTask.cpp | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/sdm845/utils/MsgTask.cpp b/sdm845/utils/MsgTask.cpp
+index eaead5c..eb5e628 100644
+--- a/sdm845/utils/MsgTask.cpp
++++ b/sdm845/utils/MsgTask.cpp
+@@ -83,7 +83,6 @@ void MsgTask::sendMsg(const LocMsg* msg) const {
+ 
+ void MsgTask::prerun() {
+     // make sure we do not run in background scheduling group
+-     set_sched_policy(gettid(), SP_FOREGROUND);
+ }
+ 
+ bool MsgTask::run() {
+-- 
+2.23.0
+

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -58,6 +58,12 @@ if [ "$SKIP_SYNC" != "TRUE" ]; then
     repo sync -j8 --current-branch --no-tags
 fi
 
+pushd $ANDROOT/build/make
+LINK="$HTTP://android.googlesource.com/platform/build"
+
+apply_gerrit_cl_commit refs/changes/28/970728/8 8453f02c652e1ec0467648064393b61c9b424d68
+popd
+
 pushd $ANDROOT/hardware/qcom/data/ipacfg-mgr/sdm845
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/sdm845/data/ipacfg-mgr"
 # guard use of kernel sources

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -104,6 +104,8 @@ apply_gerrit_cl_commit refs/changes/00/1112100/2 eeecf8a399080598e5290d3356b0ad5
 # hal: msm8916: Fix for vndk compilation errors
 # Change-Id: Iffd8a3c00a2a1ad063e10c0ebf3ce9e88e3edea0
 apply_gerrit_cl_commit refs/changes/14/777714/1 065ec9c4857fdd092d689a0526e0caeaaa6b1d72
+
+apply_local_patches
 popd
 
 pushd $ANDROOT/hardware/qcom/media

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -117,25 +117,6 @@ apply_gerrit_cl_commit refs/changes/80/832780/1 3a2fe3ec7974f9f1e9772d0009dc4df0
 apply_gerrit_cl_commit refs/changes/84/832784/1 07a63defb34cd0a18849d4488ef11a8793e6cf3b
 popd
 
-pushd $ANDROOT/hardware/qcom/display
-LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/display"
-# sdm: core: Update the mixer, framebuffer and display properly
-# Change-Id: I8e1324787e35f2c675f1c8580901fb3fadc8f3c9
-apply_gerrit_cl_commit refs/changes/09/729209/2 c62b4c1d5aeb39562d2241238082a73f39a7ea1b
-# hwc2: Do not treat color mode errors as fatal at init
-# Change-Id: I56926f320eb7719a22475793322d19244dd5d4d5
-apply_gerrit_cl_commit refs/changes/10/729210/1 ae41c6d8047767f2cd84f6d4e7ef36c653bbb8f5
-# msm8998: gralloc1: disable UBWC if video encoder client has no support
-# Change-Id: I1ff2489b0ce8fe36a801881b848873e591077402
-apply_gerrit_cl_commit refs/changes/11/729211/1 8dcf282bcec842ae633f43fc6dd1ecb397986d5c
-# color_manager: Update display color api libname
-# Change-Id: I3626975ddff8458c641dc60b3632581512f91b94
-apply_gerrit_cl_commit refs/changes/12/729212/1 977eaf6520b189100df7729644a062a2fd9a6bc4
-# msm8998: sdm: hwc2: Added property to disable skipping client color transform.
-# Change-Id: I5e2508b2de391007f93064fe5bd506dd62050fbc
-apply_gerrit_cl_commit refs/changes/13/729213/1 7f8016eb2f5b090847e70b69c08cae555add6e7f
-popd
-
 pushd $ANDROOT/hardware/qcom/bt
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/bt"
 # bt: use TARGET_BOARD_AUTO to override qcom hals

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -48,51 +48,6 @@ if [ "$SKIP_SYNC" != "TRUE" ]; then
     repo sync -j8 --current-branch --no-tags
 fi
 
-pushd $ANDROOT/art
-LINK=$HTTP && LINK+="://android.googlesource.com/platform/art"
-#ART: Add support for ARMv8.x features for ARM64.
-#Change-Id: I3ae9db34507a3bb740fc0b7ceb335486dccdf460
-apply_gerrit_cl_commit refs/changes/97/1112097/2 7de7c4cd0c8f800caa8c5f240eabd3965ac05ac3
-
-#ART: Support kryo385 CPU.
-#Change-Id: Iede5830093497abe753a34df3bc4913468be39d0
-apply_gerrit_cl_commit refs/changes/29/837429/3 b06fbf7dfdb360885a1791b61c8943200c77e4e6
-popd
-
-pushd $ANDROOT/build/make/
-LINK=$HTTP && LINK+="://android.googlesource.com/platform/build"
-# Add A76 to known v8-a cores
-# Change-Id: Ice05e7d4996252cfe4a9881a628c11b0f12cfd1b
-apply_gerrit_cl_commit refs/changes/56/787356/3 e211f7cd2dc419af8142df2bcb062f7a8b126843
-
-# Remove denver64 from make
-# Change-Id: I8f28c7d6beaa5b0a7de9000ebea2f4d8e87f0381
-apply_gerrit_cl_commit refs/changes/49/839749/3 6201b9eb5a91db2cb389838734e004a87505c807
-
-# Enable armv8-2a supporting on 2nd arch. variant
-# Change-Id: I1cd64ab0ad9b253ec3d109ebd1dbc7882011ce77
-apply_gerrit_cl_commit refs/changes/21/824721/1 ead02eb87d6424b39cad9596cde53f643edadb51
-
-# Support kryo385 CPU.
-# Change-Id: Iede5830093497abe753a34df3bc4913468be39d0
-apply_gerrit_cl_commit refs/changes/90/837390/3 f7dccc6bc077f9f95bcfad0e49f19f64aed44fc9
-popd
-
-pushd $ANDROOT/build/soong
-LINK=$HTTP && LINK+="://android.googlesource.com/platform/build/soong"
-# Add to support armv8-2a on 2nd arch. variant
-# Change-Id: I755b8858726bd887068923123bad106aed7b1ec8
-apply_gerrit_cl_commit refs/changes/02/824502/2 270ba75991b6c8f02123ad1b016346f7ca0fea33
-
-# Add support for cortex-a76 in soong
-# Change-Id: Iae0773d54e57b247c818d44f8044180d5a3f95a8
-apply_gerrit_cl_commit refs/changes/56/787256/3 a31e2bda893910fa938099c4417e4b36d7513667
-
-# Support Qualcomm Kryo 385 CPU variant.
-# I62ffb46b1977b48446c6c1ca1400b1b39f7a8457
-apply_gerrit_cl_commit refs/changes/60/831260/4 d3072b0c7cef7f5a217a055e66d85890c78620bc
-popd
-
 pushd $ANDROOT/hardware/qcom/data/ipacfg-mgr/sdm845
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/sdm845/data/ipacfg-mgr"
 # guard use of kernel sources

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -172,7 +172,7 @@ apply_gerrit_cl_commit refs/changes/75/728575/1 d6f654b013b00fa55b5c50f3f599df50
 apply_gerrit_cl_commit refs/changes/05/728605/1 b6f563436ca1b1496bf6026453e5b805c856f9e6
 # SystemUI: Implement burn-in protection for status-bar/nav-bar items
 # Change-Id: I828dbd4029b4d3b1f2c86b682a03642e3f9aeeb9
-apply_gerrit_cl_commit refs/changes/40/824340/1 6272c6244d2b007eb6ad08fb682d77612555d1ac
+apply_gerrit_cl_commit refs/changes/13/1117113/1 3531822d8f36daa2f60f009b3dfdc03817d936e1
 popd
 
 # because "set -e" is used above, when we get to this point, we know

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -99,6 +99,14 @@ LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/audio"
 # Change-Id: I749609aabfed53e8adb3575695c248bf9a674874
 git revert --no-edit 39a2b8a03c0a8a44940ac732f636d9cc1959eff2
 
+# Switch msmnile to new Audio HAL
+# Change-Id: I28e8c28822b29af68b52eb84f07f1eca746afa6d
+git revert --no-edit d0d5c9135fed70a25a42f09f0e32b056bc7b15a8
+
+# switch sm8150 to msmnile
+# Change-id: I37b9461240551037812b35d96d0b2db5e30bae5f
+git revert --no-edit 8e9b92d2c87e9d1cd96ef153853287cb79d5934c
+
 #Add msm8976 tasha sound card detection to msm8916 HAL
 #Change-Id:  Idc5ab339bb9c898205986ba0b4c7cc91febf19de
 apply_gerrit_cl_commit refs/changes/99/1112099/2 5d6e73eca6f83ce5e7375aa1bd6ed61143d30978

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -154,9 +154,8 @@ popd
 
 pushd $ANDROOT/frameworks/base
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/frameworks/base"
-# Add camera key long press handling
-# Change-Id: I9e68032eee221c20608f0d2c491c2b308350f7f6
-apply_gerrit_cl_commit refs/changes/15/727815/1 7913f55462b61c17b0700cf57d3f1a375bb4c565
+apply_local_patches
+
 # fwb: Add check for odm version
 # Change-Id: Ifab6ca5c2f97840bb4192226f191e624267edb32
 apply_gerrit_cl_commit refs/changes/75/728575/1 d6f654b013b00fa55b5c50f3f599df50847811bb

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -40,6 +40,16 @@ apply_gerrit_cl_commit() {
     fi
 }
 
+apply_local_patches() {
+    _path="${PWD#"$ANDROOT/"}"
+
+    for patch in $ANDROOT/vendor/oss/repo_update/$_path/*.patch
+    do
+        echo applying $patch
+        git am $patch
+    done
+}
+
 if [ "$SKIP_SYNC" != "TRUE" ]; then
     pushd $ANDROOT/.repo/local_manifests
     git pull
@@ -68,6 +78,8 @@ git revert --no-edit f475797d3c031ae97a393fa3e899034836fe7ba6
 git revert --no-edit 35a95e0a9bc9aeab1bb1847180babda2da5fbf90
 # Revert "DO NOT MERGE: Revert "Revert "sdm845: Add libprocessgroup dependency to set_sched_policy users""
 git revert --no-edit db96236976a195bda833d821d584bc76ea4cdbae
+
+apply_local_patches
 
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/sdm845/gps"
 # gps: sdm845: gnss: use correct format specifier in log
@@ -138,13 +150,7 @@ apply_gerrit_cl_commit refs/changes/70/728570/2 0ae34c3a19fb0a1a0bd9775199692d55
 popd
 
 pushd $ANDROOT/hardware/nxp/nfc
-LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/nxp/nfc"
-# hardware: nxp: Restore pn548 support
-# Change-Id: Iafb0d31626d0a8b9faf22f5307ac8b0a5a9ded37
-apply_gerrit_cl_commit refs/changes/61/744361/2 e3f2e87aaf9a24d61e3e3e350854d6da360696d8
-# hardware: nxp: Restore pn547 support
-# Change-Id: I498367f676f8c8d7fc13e849509d0d8a05ec89a8
-apply_gerrit_cl_commit refs/changes/62/744362/5 6629cfdaf4c41f09b69874e5d0c40552c197a517
+apply_local_patches
 popd
 
 pushd $ANDROOT/frameworks/base

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -145,16 +145,7 @@ apply_gerrit_cl_commit refs/changes/69/728569/1 e0e30f0d46ef2ff5bcb707eaf47a596c
 popd
 
 pushd $ANDROOT/hardware/qcom/bootctrl
-LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/bootctrl"
-# bootcontrol: Add TARGET_USES_HARDWARE_QCOM_BOOTCTRL
-# Change-Id: I958bcf29da2ea5914ac503e9d209c75ce44f1e51
-git revert --no-edit f5db01c3b14d720f3d603cfb3b887d89c2b11b28
-# Android.mk: add sdm710
-# Change-Id: I82f2321d580cb2fdb15d2343e39abed5ccda50b1
-git revert --no-edit a8e07aecb24898d7d2b49cb785b0c193a4b134b4
-# Replace hardcoded build barrier with a generic one
-# Change-Id: I34ee90a2818ad23cc6b9233bdde126a0965fae0d
-apply_gerrit_cl_commit refs/changes/70/728570/2 0ae34c3a19fb0a1a0bd9775199692d550af4b8f5
+apply_local_patches
 popd
 
 pushd $ANDROOT/hardware/nxp/nfc

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -93,13 +93,6 @@ apply_gerrit_cl_commit refs/changes/56/787256/3 a31e2bda893910fa938099c4417e4b36
 apply_gerrit_cl_commit refs/changes/60/831260/4 d3072b0c7cef7f5a217a055e66d85890c78620bc
 popd
 
-pushd $ANDROOT/bionic
-LINK=$HTTP && LINK+="://android.googlesource.com/platform/bionic"
-# clean_header: Write to correct dst_file
-# Change-Id: I8c5e284ce7a6737d77a2f5ead3e7e5db01317425
-apply_gerrit_cl_commit refs/changes/34/936634/2 316f4a499c4e0e014f59e1207090f84303c5bf7d
-popd
-
 pushd $ANDROOT/hardware/qcom/data/ipacfg-mgr/sdm845
 LINK=$HTTP && LINK+="://android.googlesource.com/platform/hardware/qcom/sdm845/data/ipacfg-mgr"
 # guard use of kernel sources

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -175,6 +175,12 @@ apply_gerrit_cl_commit refs/changes/05/728605/1 b6f563436ca1b1496bf6026453e5b805
 apply_gerrit_cl_commit refs/changes/13/1117113/1 3531822d8f36daa2f60f009b3dfdc03817d936e1
 popd
 
+pushd $ANDROOT/system/extras
+LINK=$HTTP && LINK+="://android.googlesource.com/platform/system/extras"
+# verity: Do not increment data when it is nullptr.
+apply_gerrit_cl_commit refs/changes/52/1117052/1 c82514bd034f214b16d273b10c676dd63a9e603b
+popd
+
 # because "set -e" is used above, when we get to this point, we know
 # all patches were applied successfully.
 echo "+++ all patches applied successfully! +++"


### PR DESCRIPTION
Apart the obvious, this contains a bunch of interesting changes:

#### Local patchfiles
While it makes _perfect_ sense to fetch patches from AOSP for as long as they are not merged, there's no point in spamming their gerrit with commits that will never get merged _anyway_.
For this reason, a very simple version of local patching has been added. It simply finds and applies (`git am`) all patches found in the same directory structure.
For now, applying all patches at once (with the sorting given by `git format-patch`) is sufficient; may we ever need to intertwine patches with AOSP fetches we can add a separate function to do just that (eg. `apply_single_patch 000x-fix-xyz.patch`).

#### Bootctrl
Patches have been dropped and we now remove the entire `Android.mk` to get rid of the old method. You can see the (much more elegant) new method using BluePrint files and shared libraries in the relevant platform repositories.

#### sm8150 audio
In order to apply previous compatibility patches, these have to be reverted. Please let me know if we use this audio hal for Kumano @jerpelea, then I can update the other patches instead.