### PR TITLE
[VERIFYME] [Android-10] fwb: Add ro.system fingerprint patch

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -173,6 +173,9 @@ apply_gerrit_cl_commit refs/changes/05/728605/1 b6f563436ca1b1496bf6026453e5b805
 # SystemUI: Implement burn-in protection for status-bar/nav-bar items
 # Change-Id: I828dbd4029b4d3b1f2c86b682a03642e3f9aeeb9
 apply_gerrit_cl_commit refs/changes/40/824340/2 cf575e7f64a976918938e6ea3bc747011fb3b551
+# core/Build: ro.system when comparing fingerprint
+# Change-Id: Ie5e972047d7983b411004a3f0d67c4636a205162
+apply_gerrit_cl_commit refs/changes/96/1147496/2 b1de316edacfbb17f395eb0277164b988aba0d86
 popd
 
 pushd $ANDROOT/system/extras


### PR DESCRIPTION
core/Build: ro.system when comparing fingerprint
    
ro.build.fingerprint is dynamically generated by deriveFingerprint(), but its output does not match ro.{system,vendor}.build.fingerprint.

See https://android-review.googlesource.com/c/platform/frameworks/base/+/1147496