### PR TITLE
[master] repo_update.sh: releasetools: Use du -b

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -101,6 +101,12 @@ enter_aosp_dir hardware/interfaces
 apply_gerrit_cl_commit refs/changes/90/1320090/1 3861f7958bec14685cde5b8fee4e590cece76d68
 popd
 
+enter_aosp_dir build
+# releasetools: Use du -b
+# Change-Id: I1955261de0f6323518b214e2731ef4879c3304e0
+apply_gerrit_cl_commit refs/changes/03/1269603/1 96a913e7f4eceb705b4e6862068117670ce31b79
+popd
+
 # because "set -e" is used above, when we get to this point, we know
 # all patches were applied successfully.
 echo "+++ all patches applied successfully! +++"


### PR DESCRIPTION
* When $OUT is on a compressed disk,
  `du -k -s` might not return the correct sizes.
* Adding `-b` gets us close to the actual size.

toybox commit: https://github.com/landley/toybox/pull/177

Test: m, builds and boots.
Devices: crosshatch blueline bonito sargo (anything with dynamic partitions)