### PR TITLE
[R] Update SystemUI burn-in protection patch and fix build on compressed file systems

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -110,6 +110,12 @@ apply_gerrit_cl_commit refs/changes/48/1295748/1 6ec651f12a9b67a9d2e41c2fe4d9a71
 apply_gerrit_cl_commit refs/changes/40/824340/3 fcc013282943c935af8225a914a525e996d42866
 popd
 
+enter_aosp_dir build/make build
+# releasetools: Use du -b
+# Change-Id: I1955261de0f6323518b214e2731ef4879c3304e0
+apply_gerrit_cl_commit refs/changes/03/1269603/1 96a913e7f4eceb705b4e6862068117670ce31b79
+popd
+
 # because "set -e" is used above, when we get to this point, we know
 # all patches were applied successfully.
 echo "+++ all patches applied successfully! +++"

--- a/repo_update.sh
+++ b/repo_update.sh
@@ -107,7 +107,7 @@ enter_aosp_dir frameworks/base
 apply_gerrit_cl_commit refs/changes/48/1295748/1 6ec651f12a9b67a9d2e41c2fe4d9a71c29d1cf34
 # SystemUI: Implement burn-in protection for status-bar/nav-bar items
 # Change-Id: I828dbd4029b4d3b1f2c86b682a03642e3f9aeeb9
-apply_gerrit_cl_commit refs/changes/40/824340/2 cf575e7f64a976918938e6ea3bc747011fb3b551
+apply_gerrit_cl_commit refs/changes/40/824340/3 fcc013282943c935af8225a914a525e996d42866
 popd
 
 # because "set -e" is used above, when we get to this point, we know


### PR DESCRIPTION
Thanks @pablomh for submitting the rebased burn-in protection patch to the original Gerrit CL! (Blame me if it breaks, I did the rebase and conflict "resolution") As well as being the guinea pig building on a compressed file system and running into annoying issues that are simply solved with `du -b` :grimacing:

@jerpelea Will you force push b676318ecf96d44aa943f28028a8a46e5ff0ac76 off or should I revert it in this PR?