### PR TITLE
[repo_update] Drop unused audio patches

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -65,36 +65,6 @@ enter_aosp_dir vendor/qcom/opensource/data/ipacfg-mgr/sdm845 hardware/qcom/sdm84
 apply_gerrit_cl_commit refs/changes/23/834623/2 0f42902cbc526d6d5badcece2add39d5badd1537
 popd
 
-enter_aosp_dir hardware/qcom/audio
-# hal: Correct mixer control name for 3.5mm headphone
-# Change-Id: I749609aabfed53e8adb3575695c248bf9a674874
-git revert --no-edit 39a2b8a03c0a8a44940ac732f636d9cc1959eff2
-
-# Switch msmnile to new Audio HAL
-# Change-Id: I28e8c28822b29af68b52eb84f07f1eca746afa6d
-git revert --no-edit d0d5c9135fed70a25a42f09f0e32b056bc7b15a8
-
-# switch sm8150 to msmnile
-# Change-id: I37b9461240551037812b35d96d0b2db5e30bae5f
-git revert --no-edit 8e9b92d2c87e9d1cd96ef153853287cb79d5934c
-
-#Add msm8976 tasha sound card detection to msm8916 HAL
-#Change-Id:  Idc5ab339bb9c898205986ba0b4c7cc91febf19de
-apply_gerrit_cl_commit refs/changes/99/1112099/2 5d6e73eca6f83ce5e7375aa1bd6ed61143d30978
-
-#hal: enable audio hal on sdm660
-#Change-Id: I7bb807788e457f7ec6ce5124dfb1d88dc96d8127
-apply_gerrit_cl_commit refs/changes/00/1112100/2 eeecf8a399080598e5290d3356b0ad557bd0ccbd
-
-# hal: msm8916: Fix for vndk compilation errors
-# Change-Id: Iffd8a3c00a2a1ad063e10c0ebf3ce9e88e3edea0
-apply_gerrit_cl_commit refs/changes/14/777714/1 065ec9c4857fdd092d689a0526e0caeaaa6b1d72
-
-# hal: msm8916: Add missing bracket to close function definition.
-# Change-Id: I8296a8fb551097fabf72115d2cec0849671b91ea
-apply_gerrit_cl_commit refs/changes/51/1118151/1 b7c1366360089d6cd1b4b18c70085a802a6a0544
-popd
-
 enter_aosp_dir hardware/interfaces
 # [android10-dev] thermal: Init module to NULL
 # Change-Id: I250006ba6fe9d91e765dde1e4534d5d87aaab879


### PR DESCRIPTION
We switched to the CAF HAL some time ago and don't need AOSP anymore. Drop all patches which are merely an extra burden to look at and maintain, for no gain.