### PR TITLE
Speed up Repo Sync for all

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -56,7 +56,7 @@ if [ "${SKIP_SYNC:-}" != "TRUE" ]; then
     git pull
     popd
 
-    repo sync -j8 --current-branch --no-tags
+    repo sync -j$(nproc) --current-branch --no-tags
 fi
 
 enter_aosp_dir bionic


### PR DESCRIPTION
Changed repo sync -j8 to repo sync -j$(nproc) which ends in significantly better Sync speeds due to use of all available CPU Threads. I checked that on My 1800X which has 16 Threads, reduced the Sync Times to the half with even a slow Internet connection. Has no bad side effects since syncing does not need much RAM at all. So no errors in case some people are building with a small amount of RAM and no Swap.