### PR TITLE
Revert "repo_update: legacy compatibility" (expose ancient Bluetooth libs)

### DIFF
--- a/repo_update.sh
+++ b/repo_update.sh
@@ -71,12 +71,6 @@ enter_aosp_dir hardware/interfaces
 apply_gerrit_cl_commit refs/changes/90/1320090/1 3861f7958bec14685cde5b8fee4e590cece76d68
 popd
 
-enter_aosp_dir packages/modules/Bluetooth
-# revert: Set Bluetooth apex updatable to true
-# Change-Id: I6822814efcc9ad5518bbb56e84df17457812c1ae
-git revert --no-edit f261e756b4f10059b6b90847cd208c95adbd8146
-popd
-
 # because "set -e" is used above, when we get to this point, we know
 # all patches were applied successfully.
 echo "+++ all patches applied successfully! +++"


### PR DESCRIPTION
This reverts commit 3f90fdcb2f8c723e3e8f981c976d7e8424719969.

The ancient Bluetooth libs are finally deprecated and disallowed from being used in Android 13; our device trees are being updated to stop using them and it is no longer needed to apply this workaround to make these modules available:

https://github.com/sonyxperiadev/device-sony-common/pull/899

For completeness the libraries weren't used for quite some time already: the configuration is only used in a fallback case when the new audio HAL is disabled by setting `persist.bluetooth.bluetooth_audio_hal.disabled` to `true` manually.
